### PR TITLE
Updated view all products to only show products the user is not selling

### DIFF
--- a/website/views/product_views.py
+++ b/website/views/product_views.py
@@ -2,7 +2,17 @@ from django.shortcuts import get_object_or_404, render
 from website.models import Product, OrderProduct, Order
 
 def list_products(request):
-    all_products = Product.objects.all()
+    if not request.user.is_authenticated:
+        all_products = Product.objects.raw(f"""
+            SELECT * FROM website_product
+        """)
+    else:
+        user_id = request.user.customer.id
+        all_products = Product.objects.raw(f"""
+            SELECT * FROM website_product
+            WHERE website_product.seller_id IS NOT {user_id}
+        """)
+
     template_name = 'product_list.html'
     return render(request, template_name, {'products': all_products})
 


### PR DESCRIPTION
# Description
This pull request fixes a bug that when logged in users access the shop page to view all products, they should only see the products they do not have listed for sale.

## Number of Fixes
1 fix included in this ticket

## Related Ticket(s)
Ticket #38 

## Steps to Test Solution

1. While logged out, select the shop item from the navbar and notice that you can view all products and their respective detail pages
1. Once you log in, if you select the shop item from the navbar you should only see the products that you have not listed for sale. 

## Testing
- [x] I certify that all existing tests pass
