### PR TITLE
fixed my products so li links to detail page

### DIFF
--- a/website/templates/my_products.html
+++ b/website/templates/my_products.html
@@ -6,7 +6,7 @@
 
 {% if products %}
 {% for product in products %}
-<div class="list-group-item list-group-item-action">
+<a href="{% url 'website:product_details' product.id %}" class="list-group-item list-group-item-action">
         <div class="d-flex w-100 justify-content-between">
           <h5 class="mb-1">{{ product.title }}</h5>
         </div>
@@ -19,7 +19,7 @@
             <a href="{% url 'website:delete_product' product.id %}" class="btn btn-danger float-right" value="Delete">Delete</a>
 
         {% endif %}
-      </div>
+      </a>
 {% endfor %}
 {% else %}
 

--- a/website/tests/test_my_products.py
+++ b/website/tests/test_my_products.py
@@ -44,7 +44,7 @@ class MyProductTest(TestCase):
         #test that page now loads but has only a notification of having no products
         response = self.client.get(reverse("website:my_products"))
         self.assertIn("<h4>You haven't listed any Products yet".encode(), response.content)
-        self.assertNotIn('<div class="list-group-item list-group-item-action"'.encode(), response.content)
+        self.assertNotIn('class="list-group-item list-group-item-action"'.encode(), response.content)
 
         product_type = ProductType.objects.create(
             name = "Test Type"
@@ -63,7 +63,7 @@ class MyProductTest(TestCase):
         #test that page now shows product added and has delete btn
         response = self.client.get(reverse("website:my_products"))
         self.assertNotIn("<h4>You haven't listed any Products yet".encode(), response.content)
-        self.assertIn('<div class="list-group-item list-group-item-action"'.encode(), response.content)
+        self.assertIn('class="list-group-item list-group-item-action"'.encode(), response.content)
         self.assertIn('<h5 class="mb-1">Test Product'.encode(), response.content)
         self.assertIn('class="btn btn-danger float-right" value="Delete"'.encode(), response.content)
 


### PR DESCRIPTION
# Description
List items in my products now link back to product detail

## Steps to Test Solution

1. Click a list item in my products and make sure it goes to the correct detail page

## Testing

- [X] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [x] I certify that all existing tests pass
