### PR TITLE
Delete Payment Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ This web application is the source code for the Bangazon e-commerce web site. It
 ## Sell a Product
 - When a user is logged in, there is an affordance in the navbar to Add a Product.
 - User can add the details for their product and add it to the market place.
+
+## Payment Types
+- From the User Settings page, Users can add payment types to their account so they can complete their order.
+- Users can also delete payment types they no longer want to use at Bangazon.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This web application is the source code for the Bangazon e-commerce web site. It
 - If you add a product to your cart and are logged in, you will be redirected to the view all products page with a success message to confirm that the product was added to your cart
 - If you try to add a product to your cart and are not currently logged in, you will be redirected to the login page with a message encouraging you to login to proceed
 
+## Search
+- Some items are available for local delivery, and users can search by city to see what is available.
+
 ## Sell a Product
 - When a user is logged in, there is an affordance in the navbar to Add a Product.
 - User can add the details for their product and add it to the market place.

--- a/website/templates/closed_order.html
+++ b/website/templates/closed_order.html
@@ -22,6 +22,6 @@
 
        <h4>Payment Type</h4>
        <p>Payment Name: {{ order.payment_type.name }}</p>
-       <p>Account Number: {{ order.payment_type.account_number }}</p>
+       <p>Account Number (last 4 digits): {{ order.payment_type.account_number|make_list|slice:"-4:"|join:"" }}</p>
 
    {% endblock content %}

--- a/website/templates/customer_profile.html
+++ b/website/templates/customer_profile.html
@@ -31,10 +31,12 @@
                 <h2 class="mt-5 mb-3">Payment Types</h2>
                 <ul class="list-group mb-3">
                     {% for payment_type in user.customer.paymenttype_set.all %}
+                        {% if not payment_type.delete_date %}
                         <li class="list-group-item d-flex">
-                            <h6 class="align-self-center m-0">{{payment_type.name}}</h6>
+                            <h6 class="align-self-center m-0">{{payment_type.name}} ({{payment_type.account_number|make_list|slice:"-4:"|join:""}})</h6>
                             <a href="{% url 'website:delete_payment_type' payment_type.id %}" class="btn btn-danger ml-auto">Delete</a>
                         </li>
+                        {% endif %}
                     {% endfor %}
 
                 </ul>
@@ -49,9 +51,9 @@
                     {% if order.payment_type_id%}
                         <form class="list-group-item d-flex" method="post" action="{% url "website:closed_order" %}">
                         {% csrf_token %}
-                        <label>BA14793NG-{{order.id}}</label>
+                        <label class="align-self-center mb-0">BA14793NG-{{order.id}}</label>
                         <input type="hidden" name="order_id" value = "{{ order.id }}">
-                        <input class="ml-auto btn-primary"  type="submit" value="View Order">
+                        <input class="ml-auto btn btn-primary"  type="submit" value="View Order">
                         </form>
                     {% endif %}
                 {% endfor %}

--- a/website/templates/customer_profile.html
+++ b/website/templates/customer_profile.html
@@ -26,14 +26,21 @@
 
         {% endif %}
 
-        <h2 class="mt-4">Payment Types</h2>
-            <ul class="list-group" >
-                {% for payment_type in user.customer.paymenttype_set.all %}
-                    <li class="list-group-item">{{payment_type.name}}</li>
-                {% endfor %}
+        <div class="row">
+            <div class="col">
+                <h2 class="mt-5 mb-3">Payment Types</h2>
+                <ul class="list-group mb-3">
+                    {% for payment_type in user.customer.paymenttype_set.all %}
+                        <li class="list-group-item d-flex">
+                            <h6 class="align-self-center m-0">{{payment_type.name}}</h6>
+                            <a href="{% url 'website:delete_payment_type' payment_type.id %}" class="btn btn-danger ml-auto">Delete</a>
+                        </li>
+                    {% endfor %}
 
-            </ul>
-            <a class="btn btn-primary mt-2 " href="{% url "website:add_payment"%}">Add Payment Type</a>
+                </ul>
+                <a class="btn btn-primary mb-5" href="{% url "website:add_payment" %}">Add Payment Type</a>
+            </div>
+        </div>
 
 
         <h2 class="mt-4">Order History</h2>

--- a/website/templates/payment_delete.html
+++ b/website/templates/payment_delete.html
@@ -1,0 +1,16 @@
+{% extends 'index.html' %}
+
+{% block content %}
+
+  <h1 class="mb-3">Delete Payment Type</h1>
+  <h4>Are you sure you want to delete {{payment_type.name}}?</h4>
+  <h6 class="text-muted">Last 4 digits: {{payment_type.account_number|make_list|slice:"-4:"|join:""}}</h6>
+  <div class="input-group mt-4">
+    <form action="{% url 'website:delete_payment_type' payment_type.id %}" method="POST">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-danger">Yes, Delete</button>
+    </form>
+    <a href="{% url 'website:customer_profile' %}" class="ml-2 btn btn-primary">Cancel</a>
+  </div>
+
+{% endblock content %}

--- a/website/tests/test_payment_delete.py
+++ b/website/tests/test_payment_delete.py
@@ -1,0 +1,154 @@
+import unittest
+from django.test import TestCase, Client
+from django.urls import reverse
+from ..models import PaymentType, User, Customer, Order
+
+
+class TestDeletePayment(TestCase):
+
+    def test_hard_delete_payment(self):
+        """ Creates user and a payment, and it should hard delete because it has not been used to complete an order.
+
+            Author: Sebastian Civarolo
+        """
+
+        new_user = User.objects.create_user(
+            username = "testuser",
+            first_name = "Test",
+            last_name = "User",
+            email = "test@test.com",
+            password = "secret"
+            )
+
+        new_customer = Customer.objects.create(
+            street_address = "123 Test LN",
+            city = "Testas",
+            state=  "TS",
+            zipcode = "11111",
+            phone_number = "1111111111",
+            user = new_user
+        )
+
+        self.client.login(username="testuser", password="secret")
+
+        new_payment_type = PaymentType.objects.create(
+            name="Test Payment",
+            customer=new_customer,
+            account_number="1234332177549012"
+        )
+
+        # Test loading the current user's payment type delete page
+        response = self.client.get(reverse("website:delete_payment_type", args=(1,)))
+        self.assertIn("Are you sure you want to delete".encode(), response.content)
+
+        # Test hard delete the current user's unused payment type
+        hard_delete_response = self.client.post(reverse("website:delete_payment_type", args=(1,)))
+        self.assertEqual(hard_delete_response.status_code, 302)
+
+        # Make sure it's really gone
+        with self.assertRaises(PaymentType.DoesNotExist):
+            payment_exists = PaymentType.objects.get(pk=1)
+
+    def test_soft_delete_payment(self):
+        """ Creates a user, payment type, and an order that uses the payment type. Should soft delete the payment type.
+
+            Author: Sebastian Civarolo
+        """
+
+        new_user = User.objects.create_user(
+            username = "testuser",
+            first_name = "Test",
+            last_name = "User",
+            email = "test@test.com",
+            password = "secret"
+            )
+
+        new_customer = Customer.objects.create(
+            street_address = "123 Test LN",
+            city = "Testas",
+            state=  "TS",
+            zipcode = "11111",
+            phone_number = "1111111111",
+            user = new_user
+        )
+
+        self.client.login(username="testuser", password="secret")
+
+        new_payment_type = PaymentType.objects.create(
+            name="Test Payment",
+            customer=new_customer,
+            account_number="1234332177549012"
+        )
+
+        new_order = Order.objects.create(
+            customer = new_customer,
+            payment_type = new_payment_type
+        )
+
+        # Test loading the current user's payment type delete page
+        response = self.client.get(reverse("website:delete_payment_type", args=(1,)))
+        self.assertIn("Are you sure you want to delete".encode(), response.content)
+
+        # Test soft delete action
+        soft_delete_response = self.client.post(reverse("website:delete_payment_type", args=(1,)))
+        self.assertEqual(soft_delete_response.status_code, 302)
+
+        # Test it is there but with a delete_date added
+        payment_exists = PaymentType.objects.get(pk=1)
+        self.assertIsNotNone(payment_exists.delete_date)
+
+    def test_delete_payment_as_another_user(self):
+        """ Creates two users, and user 2 tries to delete user 1's payment type and should be redirected.
+
+            Author: Sebastian Civarolo
+        """
+
+        new_user = User.objects.create_user(
+            username = "testuser",
+            first_name = "Test",
+            last_name = "User",
+            email = "test@test.com",
+            password = "secret"
+            )
+
+        new_customer = Customer.objects.create(
+            street_address = "123 Test LN",
+            city = "Testas",
+            state=  "TS",
+            zipcode = "11111",
+            phone_number = "1111111111",
+            user = new_user
+        )
+
+        evil_user = User.objects.create_user(
+            username = "eviluser",
+            first_name = "Test",
+            last_name = "User",
+            email = "evil@test.com",
+            password = "secret"
+        )
+
+        evil_customer = Customer.objects.create(
+            street_address = "123 Test LN",
+            city = "Testas",
+            state=  "TS",
+            zipcode = "11111",
+            phone_number = "1111111111",
+            user = evil_user
+        )
+
+        new_payment_type = PaymentType.objects.create(
+            name="Test Payment",
+            customer=new_customer,
+            account_number="1234332177549012"
+        )
+
+        self.client.login(username="eviluser", password="secret")
+
+        # Try to load the delete payment page for another user's card
+        response = self.client.get(reverse("website:delete_payment_type", args=(1,)))
+        card_exists = PaymentType.objects.get(pk=1)
+
+        # Test that the malicious user is redirected back to the user settings page instead of deleting the card
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(new_payment_type, card_exists)

--- a/website/urls.py
+++ b/website/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("cart/payment", views.payment, name='payment'),
     # ex. /website/customer/add_payment
     path("customer/add_payment", views.add_payment, name="add_payment"),
+    path("customer/payment/<int:payment_id>/delete", views.delete_payment_type, name="delete_payment_type"),
     # ex. /website/products
     path("products/", views.list_products, name='products'),
     # ex. /website/products/5

--- a/website/views/payment_views.py
+++ b/website/views/payment_views.py
@@ -20,6 +20,7 @@ def add_payment(request):
         render -- loads the payment_form.html template using the PaymentForm class in forms.py when originally navigating to the page
         HttpResponseRedirect -- TODO: loads the customer profile if add was successful
     """
+
     customer = request.user.customer
 
     if request.method == "GET":
@@ -38,7 +39,7 @@ def add_payment(request):
                 with connection.cursor() as cursor:
                     cursor.execute(sql, [name, account_number, customer.id])
                     # messages.success(request, 'Saved!')
-                return HttpResponseRedirect(reverse("website:index"))
+                return HttpResponseRedirect(reverse("website:customer_profile"))
 
 
 @login_required(login_url="/website/login")

--- a/website/views/payment_views.py
+++ b/website/views/payment_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.shortcuts import get_object_or_404, render
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
@@ -37,3 +39,70 @@ def add_payment(request):
                     cursor.execute(sql, [name, account_number, customer.id])
                     # messages.success(request, 'Saved!')
                 return HttpResponseRedirect(reverse("website:index"))
+
+
+@login_required(login_url="/website/login")
+def delete_payment_type(request, payment_id):
+    """Delete a payment type if it is the current user's.
+
+        Author: Sebastian Civarolo
+
+        Params:
+            payment_id [int] - ID to query
+
+        Returns:
+            If payment_type.customer_id matches current user, confirmation page
+            If payment_type.customer_id does not match current user, redirect to user settings
+    """
+
+    if request.method == "GET":
+
+        customer_id = request.user.customer.id
+
+        # Get the payment type from the Database
+        payment_type = PaymentType.objects.raw('''
+            SELECT * FROM website_paymenttype
+            WHERE id = %s
+        ''', [payment_id])
+
+        if request.user.customer.id == payment_type[0].customer_id:
+            context = {
+                "payment_type": payment_type[0]
+            }
+            return render(request, "payment_delete.html", context)
+        else:
+            # If someone tries to manually go to delete a payment type url that is not theirs, redirect them.
+            return HttpResponseRedirect(reverse("website:customer_profile"))
+
+
+    elif request.method == "POST":
+
+        orders_sql = """
+            SELECT * FROM website_order
+            WHERE website_order.payment_type_id == %s
+        """
+
+        orders_with_payment = Order.objects.raw(orders_sql, [payment_id])
+
+        if len(orders_with_payment):
+            sql_soft_delete = """
+                UPDATE website_paymenttype
+                SET delete_date = %s
+                WHERE id = %s
+            """
+            values = [datetime.datetime.now(), payment_id]
+            with connection.cursor() as cursor:
+                cursor.execute(sql_soft_delete, values)
+
+        else:
+            sql_delete = """
+                DELETE FROM website_paymenttype
+                WHERE id = %s
+            """
+            values = [payment_id]
+            with connection.cursor() as cursor:
+                cursor.execute(sql_delete, values)
+
+
+
+        return HttpResponseRedirect(reverse("website:customer_profile"))

--- a/website/views/payment_views.py
+++ b/website/views/payment_views.py
@@ -66,6 +66,7 @@ def delete_payment_type(request, payment_id):
         ''', [payment_id])
 
         if request.user.customer.id == payment_type[0].customer_id:
+            # Load the confirmation page if current user owns this payment type
             context = {
                 "payment_type": payment_type[0]
             }
@@ -85,6 +86,7 @@ def delete_payment_type(request, payment_id):
         orders_with_payment = Order.objects.raw(orders_sql, [payment_id])
 
         if len(orders_with_payment):
+            # Soft delete if this payment type has been used to complete an order.
             sql_soft_delete = """
                 UPDATE website_paymenttype
                 SET delete_date = %s
@@ -95,6 +97,7 @@ def delete_payment_type(request, payment_id):
                 cursor.execute(sql_soft_delete, values)
 
         else:
+            # If this payment type has never been used, hard delete.
             sql_delete = """
                 DELETE FROM website_paymenttype
                 WHERE id = %s
@@ -102,7 +105,5 @@ def delete_payment_type(request, payment_id):
             values = [payment_id]
             with connection.cursor() as cursor:
                 cursor.execute(sql_delete, values)
-
-
 
         return HttpResponseRedirect(reverse("website:customer_profile"))


### PR DESCRIPTION
# Description
Allows customers to delete their payment types.

## Related Ticket(s)
List related ticket(s) that apply to the work done in this pull request

## Proposed Changes
Describe the proposed changes.

## Expected Behavior
If the payment type has never been used on an order, it should **hard delete**
If the payment type has been used on an order, it should **soft delete**
Also, going manually to a url for a card that is not yours should redirect you away.

## Steps to Test Solution

1. With multiple payment options, use one to complete an order, and keep one unused.
2. Delete both payment types and check the database.
3. Used card should have a delete_date entry
4. Unused card should be gone.
5. Added delete_date condition to user settings view, and should also be hidden on choosing payment type to complete order.

## Testing

- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [x] I certify that all existing tests pass

## Documentation
- [x] There is new documentation in this pull request that must be reviewed..
- [x] I added documentation for any new classes/methods