### PR TITLE
Bm-cancel-order

### DIFF
--- a/website/templates/cart.html
+++ b/website/templates/cart.html
@@ -3,10 +3,26 @@
 
 {% block content %}
 
-{% if order %}
+{% if delete_confirmation %}
   <h1>{{request.user}}'s cart</h1>
   <div>Order Number: BA14793NG-{{order_id}}</div>
   <hr />
+  Are you sure you want to cancel this order?
+  <form action="{% url 'website:cart' %}" method="POST" class="p-1">
+    {% csrf_token %}
+      <a class="btn btn-outline-secondary" href="{% url 'website:cart' %}">Go to Cart</a>
+      <a href="{% url 'website:products' %}" class="btn btn-outline-secondary">View More Products</a>
+      <input type="hidden" value="{{ order_id }}" name="order_id">
+      <input type="hidden" value="{{ products }}" name="products">
+      <input type="hidden" value="confirmed_deletion" name="confirmed_deletion">
+      <button class="btn btn-danger">Confirm Cancellation</button>
+  </form>
+
+{% elif order %}
+  <h1>{{request.user}}'s cart</h1>
+  <div>Order Number: BA14793NG-{{order_id}}</div>
+  <hr />
+
   {% for product in products %}
     <a class="list-group-item bg-light list-group-item-action" href="{% url 'website:product_details' product.product_id %}">
       <div class="d-flex w-100">
@@ -14,9 +30,9 @@
         <div class="p-2">${{product.price|intcomma}}</div>
         <form action="{% url 'website:cart' %}" method="POST" class="p-1">
           {% csrf_token %}
-          <input type="hidden" value="{{ product.product_id }}" name="product_id">
-          <input type="hidden" value="{{ order_id }}" name="order_id">
-          <button class="btn btn-danger btn-sm">Delete</button>
+            <input type="hidden" value="{{ product.product_id }}" name="product_id">
+            <input type="hidden" value="{{ order_id }}" name="order_id">
+            <button class="btn btn-danger btn-sm">Delete</button>
         </form>
       </div>
       <div class="d-flex w-100 justify-content-between">
@@ -24,11 +40,20 @@
       </div>
     </a>
   {% endfor %}
+
   <hr />
   <div class="list-group-item bg-light">Order total: <strong>${{total|intcomma}}</strong></div>
   <hr />
-    <a class="btn btn-primary" href="{% url 'website:payment' %}">Complete Order</a>
-    <a href="{% url 'website:products' %}" class="btn btn-outline-secondary">View More Products</a>
+  <form action="{% url 'website:cart' %}" method="POST" class="p-1">
+    {% csrf_token %}
+      <a class="btn btn-primary" href="{% url 'website:payment' %}">Complete Order</a>
+      <a href="{% url 'website:products' %}" class="btn btn-outline-secondary">View More Products</a>
+      <input type="hidden" value="{{ order_id }}" name="order_id">
+      <input type="hidden" value="{{ products }}" name="products">
+      <input type="hidden" value="empty_cart" name="empty_cart">
+      <button class="btn btn-danger">Cancel Order</button>
+  </form>
+
 {% else %}
   <div>
     <strong>You don't have an open order...</strong>

--- a/website/templates/cart.html
+++ b/website/templates/cart.html
@@ -13,7 +13,6 @@
       <a class="btn btn-outline-secondary" href="{% url 'website:cart' %}">Go to Cart</a>
       <a href="{% url 'website:products' %}" class="btn btn-outline-secondary">View More Products</a>
       <input type="hidden" value="{{ order_id }}" name="order_id">
-      <input type="hidden" value="{{ products }}" name="products">
       <input type="hidden" value="confirmed_deletion" name="confirmed_deletion">
       <button class="btn btn-danger">Confirm Cancellation</button>
   </form>
@@ -49,7 +48,6 @@
       <a class="btn btn-primary" href="{% url 'website:payment' %}">Complete Order</a>
       <a href="{% url 'website:products' %}" class="btn btn-outline-secondary">View More Products</a>
       <input type="hidden" value="{{ order_id }}" name="order_id">
-      <input type="hidden" value="{{ products }}" name="products">
       <input type="hidden" value="empty_cart" name="empty_cart">
       <button class="btn btn-danger">Cancel Order</button>
   </form>

--- a/website/templates/cart.html
+++ b/website/templates/cart.html
@@ -29,7 +29,7 @@
         <div class="p-2">${{product.price|intcomma}}</div>
         <form action="{% url 'website:cart' %}" method="POST" class="p-1">
           {% csrf_token %}
-            <input type="hidden" value="{{ product.product_id }}" name="product_id">
+            <input type="hidden" value="{{ product.order_product_id }}" name="order_product_id">
             <input type="hidden" value="{{ order_id }}" name="order_id">
             <button class="btn btn-danger btn-sm">Delete</button>
         </form>

--- a/website/tests/test_remove_from_cart.py
+++ b/website/tests/test_remove_from_cart.py
@@ -67,7 +67,7 @@ class DeleteProductFromCartTest(TestCase):
         self.assertIn(product.title.encode(), response.content)
 
         # confirm that post returns a response of 302
-        response = self.client.post(reverse("website:cart"), {"product_id": 1, "order_id": 1})
+        response = self.client.post(reverse("website:cart"), {"order_product_id": 1, "order_id": 1})
         self.assertEqual(response.status_code, 302)
 
         # confirm that the open order is also deleted, since only one object was created

--- a/website/tests/test_remove_from_cart.py
+++ b/website/tests/test_remove_from_cart.py
@@ -4,6 +4,7 @@ from ..models import *
 from django.test import Client
 from django.urls import reverse
 
+
 class DeleteProductFromCartTest(TestCase):
     """Tests the deletion of a product from a user's cart and the removal of an open order
 
@@ -68,6 +69,104 @@ class DeleteProductFromCartTest(TestCase):
 
         # confirm that post returns a response of 302
         response = self.client.post(reverse("website:cart"), {"order_product_id": 1, "order_id": 1})
+        self.assertEqual(response.status_code, 302)
+
+        # confirm that the open order is also deleted, since only one object was created
+        no_order = Order.objects.filter(pk=1)
+        self.assertEqual(len(no_order), 0)
+
+    def test_cancel_order(self):
+        """Tests that an open order with multiple items will be deleted completely and all order_product join tables are also removed from the database."""
+
+        # create new user, log them in, and assign to customer
+        new_user= User.objects.create_user(
+            username = "testuser",
+            first_name = "Test",
+            last_name = "User",
+            email = "test@test.com",
+            password = "password"
+            )
+
+        self.client.login(username="testuser", password="password")
+
+        Customer.objects.create(
+            street_address = "123 Test Street",
+            city = "Test",
+            state = "TS",
+            zipcode = "11111",
+            phone_number = "1111111111",
+            user = new_user
+            )
+
+        # create an order with associated products and an available payment type
+        Order.objects.create(
+            customer_id = 1,
+        )
+
+        PaymentType.objects.create(
+            name = "User's credit card",
+            account_number = 123456789,
+            delete_date = None,
+            customer_id = 1
+        )
+
+        OrderProduct.objects.create(
+            order_id = 1,
+            product_id = 1
+        )
+
+        OrderProduct.objects.create(
+            order_id = 1,
+            product_id = 2
+        )
+
+        OrderProduct.objects.create(
+            order_id = 1,
+            product_id = 3
+        )
+
+        product = Product.objects.create(
+            title = "Item 1",
+            description = "Something nice",
+            price = 25,
+            quantity = 1,
+            delete_date = None,
+            product_type_id = 1,
+            seller_id = 2
+        )
+
+        product2 = Product.objects.create(
+            title = "Item 2",
+            description = "Something nice",
+            price = 25,
+            quantity = 1,
+            delete_date = None,
+            product_type_id = 1,
+            seller_id = 2
+        )
+
+        product3 = Product.objects.create(
+            title = "Item 3",
+            description = "Something nice",
+            price = 25,
+            quantity = 1,
+            delete_date = None,
+            product_type_id = 1,
+            seller_id = 2
+        )
+
+        # Confirm that product titles appear in cart
+        response = self.client.get(reverse('website:cart'))
+        self.assertIn(product.title.encode(), response.content)
+
+        response = self.client.get(reverse('website:cart'))
+        self.assertIn(product2.title.encode(), response.content)
+
+        response = self.client.get(reverse('website:cart'))
+        self.assertIn(product3.title.encode(), response.content)
+
+        # confirm that post returns a response of 302
+        response = self.client.post(reverse("website:cart"), {"confirmed_deletion": True, "order_id": 1})
         self.assertEqual(response.status_code, 302)
 
         # confirm that the open order is also deleted, since only one object was created

--- a/website/views/cart.py
+++ b/website/views/cart.py
@@ -43,9 +43,10 @@ def cart(request):
     if request.method == "POST":
 
         try:
-            cancel_order_confirmation = request.POST["confirmed_deletion"] # if this is exists on POST, then the user has confirmed the order's deletion. else -> except
+            cancel_order_confirmation = request.POST["confirmed_deletion"] # if this is exists on POST, then the user has confirmed the order's deletion. if not -> except
             order_id = request.POST["order_id"]
-            products = request.POST["products"]
+
+            products = Order.objects.raw(sql, [customer_id])
 
             for product in products:
                 with connection.cursor() as cursor:
@@ -59,8 +60,8 @@ def cart(request):
         except:
 
             try:
-                cancel_order = request.POST["empty_cart"] # if this exists on POST, then the user clicked the cancel all button, so prompt for confirmation
-                context = {"order_id": request.POST["order_id"], "products": request.POST["products"], "delete_confirmation": True}
+                cancel_order = request.POST["empty_cart"] # if this exists on POST, then the user clicked the cancel all button, so prompt for confirmation. if not -> except
+                context = {"order_id": request.POST["order_id"], "delete_confirmation": True}
                 return render(request, "cart.html", context)
 
             except:


### PR DESCRIPTION
# Description
- Clicking cancel order will prompt the user with a confirmation screen.
- Clicking confirm will delete all OrderProduct tables associated with the order, in addition to the open order itself.

## Number of Fixes
- Deleting a product in the cart (that has more than one instance in the cart) will only remove one of the items, not all of them

## Related Ticket(s)
#10 

## Steps to Test Solution

1. pyman test

## Testing

- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [x] I certify that all existing tests pass